### PR TITLE
browserName capability deleted in Native App testing per v1.9

### DIFF
--- a/Java/Advanced(Continued...)/Chapter 04- TestNG with pCloudy Appium with Extent Reports(Android Native + TestNG)/src/com/testng/pCloudy/Controller.java
+++ b/Java/Advanced(Continued...)/Chapter 04- TestNG with pCloudy Appium with Extent Reports(Android Native + TestNG)/src/com/testng/pCloudy/Controller.java
@@ -95,7 +95,6 @@ public class Controller {
 			capabilities.setCapability("newCommandTimeout", 600);
 			capabilities.setCapability("launchTimeout", 90000);
 			capabilities.setCapability("deviceName", aDevice.capabilities.deviceName);
-			capabilities.setCapability("browserName", aDevice.capabilities.deviceName);
 			capabilities.setCapability("platformName", "Android");
 			capabilities.setCapability("appPackage", "com.pcloudy.appiumdemo");
 			capabilities.setCapability("appActivity", "com.ba.mobile.LaunchActivity");

--- a/Java/Advanced(Continued...)/Chapter 05- TestNG with pCloudy Appium with pCloudy Reports(Android Native + TestNG)/src/com/pcloudy/testng/Controller.java
+++ b/Java/Advanced(Continued...)/Chapter 05- TestNG with pCloudy Appium with pCloudy Reports(Android Native + TestNG)/src/com/pcloudy/testng/Controller.java
@@ -106,7 +106,6 @@ public class Controller {
 			capabilities.setCapability("newCommandTimeout", 600);
 			capabilities.setCapability("launchTimeout", 90000);
 			capabilities.setCapability("deviceName", aDevice.capabilities.deviceName);
-			capabilities.setCapability("browserName", aDevice.capabilities.deviceName);
 			capabilities.setCapability("platformName", "Android");
 			capabilities.setCapability("appPackage", "com.pcloudy.appiumdemo");
 			capabilities.setCapability("appActivity", "com.ba.mobile.LaunchActivity");

--- a/Java/Advanced(Continued...)/Chapter 07- TestNG with pCloudy Appium with pCloudy Reports(iOS Native + TestNG)/src/com/pcloudy/testng/Controller.java
+++ b/Java/Advanced(Continued...)/Chapter 07- TestNG with pCloudy Appium with pCloudy Reports(iOS Native + TestNG)/src/com/pcloudy/testng/Controller.java
@@ -105,7 +105,6 @@ public class Controller {
 			capabilities.setCapability("newCommandTimeout", 600);
 			capabilities.setCapability("launchTimeout", 90000);
 			capabilities.setCapability("deviceName", aDevice.capabilities.deviceName);
-			capabilities.setCapability("browserName", aDevice.capabilities.browserName);
 			capabilities.setCapability("platformName", "iOS");
 			capabilities.setCapability("bundleId", "com.pcloudy.TestmunkDemo");
 

--- a/Java/Advanced(Continued...)/Chapter 09- Java MultiThread with pCloudy Appium with pCloudy Reports(Android Native + Java Threading)/src/com/ssts/BritishAirwaysAppium.java
+++ b/Java/Advanced(Continued...)/Chapter 09- Java MultiThread with pCloudy Appium with pCloudy Reports(Android Native + Java Threading)/src/com/ssts/BritishAirwaysAppium.java
@@ -134,7 +134,6 @@ public class BritishAirwaysAppium {
 					capabilities.setCapability("newCommandTimeout", 600);
 					capabilities.setCapability("launchTimeout", 90000);
 					capabilities.setCapability("deviceName", aDevice.capabilities.deviceName);
-					capabilities.setCapability("browserName", aDevice.capabilities.deviceName);
 					capabilities.setCapability("platformName", "Android");
 					capabilities.setCapability("appPackage", "com.pcloudy.appiumdemo");
 					capabilities.setCapability("appActivity", "com.ba.mobile.LaunchActivity");

--- a/Java/Advanced(Continued...)/Chapter 10- Java MultiThread with pCloudy Appium with pCloudy Reports(iOS Native + Java Threading)/src/TestScript/MainClass.java
+++ b/Java/Advanced(Continued...)/Chapter 10- Java MultiThread with pCloudy Appium with pCloudy Reports(iOS Native + Java Threading)/src/TestScript/MainClass.java
@@ -181,7 +181,6 @@ public class MainClass {
 			capabilities.setCapability("newCommandTimeout", 600);
 			capabilities.setCapability("launchTimeout", 90000);
 			capabilities.setCapability("deviceName", aDevice.capabilities.deviceName);
-			capabilities.setCapability("browserName", aDevice.capabilities.browserName);
 			capabilities.setCapability("platformName", "iOS");
 			capabilities.setCapability("bundleId", "com.pcloudy.TestmunkDemo");
 

--- a/Java/Advanced(Continued...)/Chapter 13- Cucumber with single Device_v1 (Android Native with Cucumber)/src/test/java/utility/Hook.java
+++ b/Java/Advanced(Continued...)/Chapter 13- Cucumber with single Device_v1 (Android Native with Cucumber)/src/test/java/utility/Hook.java
@@ -68,7 +68,6 @@ public class Hook {
 		capabilities.setCapability("newCommandTimeout", 600);
 		capabilities.setCapability("launchTimeout", 90000);
 		capabilities.setCapability("deviceName", pCloudySession.getDto().capabilities.deviceName);
-		capabilities.setCapability("browserName", pCloudySession.getDto().capabilities.deviceName);
 		capabilities.setCapability("platformName", "Android");
 		capabilities.setCapability("appPackage", "io.appium.android.apis");
 		capabilities.setCapability("appActivity", "io.appium.android.apis.ApiDemos");

--- a/Java/Advanced(Continued...)/Chapter 14- Jenkins and TestNG with pCloudy Appium with pCloudy Reports(Android Native + TestNG)/src/com/pcloudy/testng/Controller.java
+++ b/Java/Advanced(Continued...)/Chapter 14- Jenkins and TestNG with pCloudy Appium with pCloudy Reports(Android Native + TestNG)/src/com/pcloudy/testng/Controller.java
@@ -105,7 +105,6 @@ public class Controller {
 			capabilities.setCapability("newCommandTimeout", 600);
 			capabilities.setCapability("launchTimeout", 90000);
 			capabilities.setCapability("deviceName", aDevice.capabilities.deviceName);
-			capabilities.setCapability("browserName", aDevice.capabilities.deviceName);
 			capabilities.setCapability("platformName", "Android");
 			capabilities.setCapability("appPackage", "com.pcloudy.appiumdemo");
 			capabilities.setCapability("appActivity", "com.ba.mobile.LaunchActivity");

--- a/Java/Getting Started/Chapter 03- TestNG with pCloudy Appium on Multiple Devices(Android Native + TestNG)/src/com/testng/pCloudy/Controller.java
+++ b/Java/Getting Started/Chapter 03- TestNG with pCloudy Appium on Multiple Devices(Android Native + TestNG)/src/com/testng/pCloudy/Controller.java
@@ -104,7 +104,6 @@ public class Controller {
 			capabilities.setCapability("newCommandTimeout", 600);
 			capabilities.setCapability("launchTimeout", 90000);
 			capabilities.setCapability("deviceName", aDevice.capabilities.deviceName);
-			capabilities.setCapability("browserName", aDevice.capabilities.deviceName);
 			capabilities.setCapability("platformName", "Android");
 			capabilities.setCapability("appPackage", "com.pcloudy.appiumdemo");
 			capabilities.setCapability("appActivity", "com.ba.mobile.LaunchActivity");


### PR DESCRIPTION
We cannot add browserName and appPackage/appActivity/bundleId capabilities at a time as per Appium v1.9.1