### PR TITLE
Wda fix for iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ hs_err_pid*
 target/
 *.dll
 *.png
+/.metadata/

--- a/Java/NewAppium_SampleProjects/Chapter1-TestNg+OnSingleDevice(Android)/src/com/pCloudy/testNG/Runner.java
+++ b/Java/NewAppium_SampleProjects/Chapter1-TestNg+OnSingleDevice(Android)/src/com/pCloudy/testNG/Runner.java
@@ -49,6 +49,7 @@ public class Runner {
 		capabilities.setCapability("platformName", "Android");
 		capabilities.setCapability("newCommandTimeout", 600);
 		capabilities.setCapability("launchTimeout", 90000);
+		capabilities.setCapability("automationName", "uiautomator2");
 		capabilities.setCapability("appPackage", "com.pcloudy.appiumdemo");
 		capabilities.setCapability("appActivity", "com.ba.mobile.LaunchActivity");
 		driver = new AndroidDriver(new URL("https://device.pcloudy.com/appiumcloud/wd/hub"), capabilities);

--- a/Java/NewAppium_SampleProjects/Chapter1-TestNg+OnSingleDevice(Android)/src/com/pCloudy/testNG/Runner.java
+++ b/Java/NewAppium_SampleProjects/Chapter1-TestNg+OnSingleDevice(Android)/src/com/pCloudy/testNG/Runner.java
@@ -42,8 +42,11 @@ public class Runner {
 		capabilities.setCapability("pCloudy_ApplicationName", "pCloudyAppiumDemo.apk");
 		capabilities.setCapability("pCloudy_DurationInMinutes", 10);
 		capabilities.setCapability("pCloudy_DeviceManafacturer", "Samsung");
-		//capabilities.setCapability("pCloudy_DeviceVersion", "8.0.0");
+		capabilities.setCapability("pCloudy_DeviceVersion", "8.0.0");
 		//capabilities.setCapability("pCloudy_DeviceFullName", "Samsung_GalaxyTabA_Android_7.1.1");
+		capabilities.setCapability("automationName", "uiautomator2");
+		capabilities.setCapability("platformVersion", "8.0.0");
+		capabilities.setCapability("platformName", "Android");
 		capabilities.setCapability("newCommandTimeout", 600);
 		capabilities.setCapability("launchTimeout", 90000);
 		capabilities.setCapability("appPackage", "com.pcloudy.appiumdemo");

--- a/Java/NewAppium_SampleProjects/Chapter2-TestNg+OnParallelDevice(Android)/src/com/pCloudy/testNG/Runner.java
+++ b/Java/NewAppium_SampleProjects/Chapter2-TestNg+OnParallelDevice(Android)/src/com/pCloudy/testNG/Runner.java
@@ -48,6 +48,7 @@ public class Runner {
 		//capabilities.setCapability("pCloudy_DeviceFullName", "Samsung_GalaxyTabA_Android_7.1.1");
 		capabilities.setCapability("newCommandTimeout", 600);
 		capabilities.setCapability("launchTimeout", 90000);
+		capabilities.setCapability("automationName", "uiautomator2");
 		capabilities.setCapability("appPackage", "com.pcloudy.appiumdemo");
 		capabilities.setCapability("appActivity", "com.ba.mobile.LaunchActivity");
 		driver = new AndroidDriver(new URL("https://device.pcloudy.com/appiumcloud/wd/hub"), capabilities);

--- a/Java/NewAppium_SampleProjects/Chapter3-TestNg+OnWeb(Android)/src/com/pCloudy/testNG/Runner.java
+++ b/Java/NewAppium_SampleProjects/Chapter3-TestNg+OnWeb(Android)/src/com/pCloudy/testNG/Runner.java
@@ -43,6 +43,7 @@ public class Runner {
 		capabilities.setCapability("pCloudy_DeviceManafacturer", "Samsung");
 		//capabilities.setCapability("pCloudy_DeviceVersion", "8.0.0");
 		//capabilities.setCapability("pCloudy_DeviceFullName", "Samsung_GalaxyTabA_Android_7.1.1");
+		capabilities.setCapability("automationName", "uiautomator2");
 		capabilities.setCapability("newCommandTimeout", 600);
 		capabilities.setCapability("launchTimeout", 90000);
 		capabilities.setBrowserName("Chrome");

--- a/Java/NewAppium_SampleProjects/Chapter4-TestNg+OnSingleDevice(iOS)/src/com/pCloudy/testNG/Runner.java
+++ b/Java/NewAppium_SampleProjects/Chapter4-TestNg+OnSingleDevice(iOS)/src/com/pCloudy/testNG/Runner.java
@@ -45,12 +45,12 @@ public class Runner {
 		capabilities.setCapability("pCloudy_ApplicationName", "TestmunkDemo.ipa");		
 		capabilities.setCapability("pCloudy_DurationInMinutes", 10);
 		capabilities.setCapability("pCloudy_DeviceManafacturer", "Apple");
-		//capabilities.setCapability("pCloudy_DeviceVersion", "10.3.2");
+		capabilities.setCapability("pCloudy_DeviceVersion", "10.3.2");
 		//capabilities.setCapability("pCloudy_DeviceFullName", "Apple_iPhone6S_Ios_11.2.0");
+		capabilities.setCapability("platformVersion", "10.3.2");
 		capabilities.setCapability("newCommandTimeout", 600);
 		capabilities.setCapability("launchTimeout", 90000);
 		capabilities.setCapability("bundleId", "com.pcloudy.TestmunkDemo");
-		capabilities.setCapability("usePrebuiltWDA", false);
 		capabilities.setCapability("acceptAlerts", true);
 		capabilities.setCapability("automationName", "XCUITest");
 		driver = new IOSDriver(new URL("https://device.pcloudy.com/appiumcloud/wd/hub"), capabilities);

--- a/Java/NewAppium_SampleProjects/Chapter5-TestNgOnParallelDevice(iOS)/src/com/pCloudy/testNG/Runner.java
+++ b/Java/NewAppium_SampleProjects/Chapter5-TestNgOnParallelDevice(iOS)/src/com/pCloudy/testNG/Runner.java
@@ -46,12 +46,12 @@ public class Runner {
 		capabilities.setCapability("pCloudy_ApplicationName", "TestmunkDemo.ipa");		
 		capabilities.setCapability("pCloudy_DurationInMinutes", 10);
 		capabilities.setCapability("pCloudy_DeviceManafacturer", deviceName);
-		//capabilities.setCapability("pCloudy_DeviceVersion", "10.3.2");
+		capabilities.setCapability("pCloudy_DeviceVersion", "10.3.2");
 		//capabilities.setCapability("pCloudy_DeviceFullName", "Apple_iPhone6S_Ios_11.2.0");
+		capabilities.setCapability("platformVersion", "10.3.2");
 		capabilities.setCapability("newCommandTimeout", 600);
 		capabilities.setCapability("launchTimeout", 90000);
 		capabilities.setCapability("bundleId", "com.pcloudy.TestmunkDemo");
-		capabilities.setCapability("usePrebuiltWDA", false);
 		capabilities.setCapability("acceptAlerts", true);
 		capabilities.setCapability("automationName", "XCUITest");
 		driver = new IOSDriver(new URL("https://device.pcloudy.com/appiumcloud/wd/hub"), capabilities);

--- a/Java/NewAppium_SampleProjects/Chapter6-TestNg+OnWeb(iOS)/src/com/pCloudy/testNG/Runner.java
+++ b/Java/NewAppium_SampleProjects/Chapter6-TestNg+OnWeb(iOS)/src/com/pCloudy/testNG/Runner.java
@@ -46,12 +46,12 @@ public class Runner {
 		capabilities.setCapability("pCloudy_ApiKey", "Enter your API Key");
 		capabilities.setCapability("pCloudy_DurationInMinutes", 10);
 		capabilities.setCapability("pCloudy_DeviceManafacturer", "Apple");
-		//capabilities.setCapability("pCloudy_DeviceVersion", "10.3.2");
+		capabilities.setCapability("pCloudy_DeviceVersion", "10.3.2");
 		//capabilities.setCapability("pCloudy_DeviceFullName", "Apple_iPhone6S_Ios_11.2.0");
+		capabilities.setCapability("platformVersion", "10.3.2");
 		capabilities.setCapability("newCommandTimeout", 600);
 		capabilities.setCapability("launchTimeout", 90000);
 		capabilities.setBrowserName("Safari");
-		capabilities.setCapability("usePrebuiltWDA", false);
 		capabilities.setCapability("acceptAlerts", true);
 		capabilities.setCapability("automationName", "XCUITest");
 		driver = new IOSDriver(new URL("https://device.pcloudy.com/appiumcloud/wd/hub"), capabilities);


### PR DESCRIPTION
removed **usePrebuiltWDA** from iOS sample project. No more required cause setting default true.
added **automationName** capability in Android Sample Projects